### PR TITLE
Update copyright, remove TODO and bump version

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright 2018 AppScale Systems, Inc
+Copyright 2018-2019 AppScale Systems, Inc
 Portions copyright 2016-2017 Ent. Services Development Corporation LP
 
 Permission to use, copy, modify, and/or distribute this software for

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ eucalyptus.if: eucalyptus.te eucalyptus.if.m4 eucalyptus.if.in
 relabel:
 	restorecon -Riv /etc/eucalyptus /usr/lib/eucalyptus /usr/lib/systemd/system/euca* /usr/sbin/euca* /usr/share/eucalyptus /var/lib/eucalyptus /var/log/eucalyptus /var/run/eucalyptus
 
-distdir: Makefile COPYING TODO eucalyptus.te eucalyptus.fc eucalyptus.if.m4 eucalyptus.if.in eucalyptus-selinux.spec
+distdir: Makefile COPYING eucalyptus.te eucalyptus.fc eucalyptus.if.m4 eucalyptus.if.in eucalyptus-selinux.spec
 	rm -rf $(distdir)
 	mkdir -p $(distdir)
 	cp -pR $^ $(distdir)

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,7 @@
-# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# Copyright 2018-2019 AppScale Systems, Inc
+# Portions copyright 2016-2017 Ent. Services Development Corporation LP
 #
-# Permission to use, copy, modify, and/or distribute this software for
-# any purpose with or without fee is hereby granted, provided that the
-# above copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# SPDX-License-Identifier: BSD-2-Clause
 
 distdir = eucalyptus-selinux-$(shell sed -n '/^policy_module/s/.*, \([0-9.]*\).*/\1/p' eucalyptus.te)
 

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-* Check svirt labels on paravirt kernels and ramdisks

--- a/eucalyptus-selinux.spec
+++ b/eucalyptus-selinux.spec
@@ -37,7 +37,6 @@ install -Dp -m 0644 eucalyptus.pp $RPM_BUILD_ROOT%{_datadir}/selinux/packages/eu
 
 %files
 %license COPYING
-%doc TODO
 %{_datadir}/selinux/devel/include/contrib/eucalyptus.if
 %{_datadir}/selinux/packages/eucalyptus.pp
 

--- a/eucalyptus-selinux.spec
+++ b/eucalyptus-selinux.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-selinux
-Version:        0.2.4
+Version:        0.2.5
 Release:        1%{?dist}
 Summary:        SELinux policy for eucalyptus
 
@@ -58,6 +58,9 @@ fi
 
 
 %changelog
+* Wed Mar 27 2019 Steve Jones <steve.jones@appscale.com> - 0.2.5-1
+- Version bump (0.2.5)
+
 * Fri Jul  6 2018 Steve Jones <steve.jones@appscale.com> - 0.2.4-1
 - Version bump (0.2.4)
 

--- a/eucalyptus.fc
+++ b/eucalyptus.fc
@@ -1,16 +1,7 @@
-# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# Copyright 2018-2019 AppScale Systems, Inc
+# Portions copyright 2016-2017 Ent. Services Development Corporation LP
 #
-# Permission to use, copy, modify, and/or distribute this software for
-# any purpose with or without fee is hereby granted, provided that the
-# above copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# SPDX-License-Identifier: BSD-2-Clause
 
 /dev/shm/sem\.eucalyptus.*                         -- gen_context(system_u:object_r:eucalyptus_tmpfs_t,s0)
 /etc/eucalyptus(/.*)?                                 gen_context(system_u:object_r:eucalyptus_conf_t,s0)

--- a/eucalyptus.if.in
+++ b/eucalyptus.if.in
@@ -1,16 +1,7 @@
-# Copyright (c) 2016 Hewlett Packard Enterprise Development LP
+# Copyright 2018-2019 AppScale Systems, Inc
+# Portions copyright 2016-2017 Ent. Services Development Corporation LP
 #
-# Permission to use, copy, modify, and/or distribute this software for
-# any purpose with or without fee is hereby granted, provided that the
-# above copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# SPDX-License-Identifier: BSD-2-Clause
 
 ## <summary>Eucalyptus cloud services.</summary>
 

--- a/eucalyptus.if.m4
+++ b/eucalyptus.if.m4
@@ -1,16 +1,7 @@
-dnl Copyright (c) 2016 Hewlett Packard Enterprise Development LP
+dnl Copyright 2018-2019 AppScale Systems, Inc
+dnl Portions copyright 2016-2017 Ent. Services Development Corporation LP
 dnl
-dnl Permission to use, copy, modify, and/or distribute this software for
-dnl any purpose with or without fee is hereby granted, provided that the
-dnl above copyright notice and this permission notice appear in all copies.
-dnl
-dnl THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-dnl WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-dnl MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-dnl ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-dnl WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-dnl ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-dnl OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+dnl SPDX-License-Identifier: BSD-2-Clause
 
 define(`eucalyptus_domain_template',``
 ########################################

--- a/eucalyptus.te
+++ b/eucalyptus.te
@@ -1,16 +1,7 @@
-# Copyright (c) 2016-2017 Ent. Services Development Corporation LP
+# Copyright 2018-2019 AppScale Systems, Inc
+# Portions copyright 2016-2017 Ent. Services Development Corporation LP
 #
-# Permission to use, copy, modify, and/or distribute this software for
-# any purpose with or without fee is hereby granted, provided that the
-# above copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+# SPDX-License-Identifier: BSD-2-Clause
 
 policy_module(eucalyptus, 0.2.4)
 


### PR DESCRIPTION
Update copyright for AppScale and the license for SPDX, the TODO file is removed and the version number bumped.