### PR TITLE
Allow cloud controller to connect to node

### DIFF
--- a/eucalyptus.te
+++ b/eucalyptus.te
@@ -133,6 +133,7 @@ corenet_udp_bind_dns_port(eucalyptus_cloud_t)
 corenet_tcp_connect_http_port(eucalyptus_cloud_t)  # for riak
 corenet_tcp_connect_ldap_port(eucalyptus_cloud_t)
 corenet_tcp_connect_osapi_compute_port(eucalyptus_cloud_t)  # port 8774
+corenet_tcp_connect_neutron_port(eucalyptus_cloud_t)  # port 8775
 
 dev_read_rand(eucalyptus_cloud_t)
 dev_read_sysfs(eucalyptus_cloud_t)  # /sys/device/system/cpu


### PR DESCRIPTION
The cloud controller now runs the cluster service which must be able to connect to nodes.